### PR TITLE
CI run: Display only the latest search results

### DIFF
--- a/ui/dialogs/searchdialog.go
+++ b/ui/dialogs/searchdialog.go
@@ -37,6 +37,8 @@ type SearchDialog struct {
 
 	imgSource     util.ImageFetcher
 	resultsMutex  sync.RWMutex
+	resultsGeneration int
+	pendingResultsGeneration int
 	searchResults []*mediaprovider.SearchResult
 	selectedIndex int
 
@@ -164,6 +166,8 @@ func (sd *SearchDialog) setResults(results []*mediaprovider.SearchResult) {
 func (sd *SearchDialog) onSearched(query string) {
 	sd.loadingDots.Start()
 	var results []*mediaprovider.SearchResult
+	sd.pendingResultsGeneration += 1
+	var generation = sd.pendingResultsGeneration
 	go func() {
 		res := sd.OnSearched(query)
 		if len(res) == 0 {
@@ -171,10 +175,15 @@ func (sd *SearchDialog) onSearched(query string) {
 		} else {
 			results = res
 		}
-		fyne.Do(func() {
-			sd.loadingDots.Stop()
-			sd.setResults(results)
-		})
+		if(sd.resultsGeneration < generation) {
+			fyne.Do(func() {
+				if(sd.pendingResultsGeneration == generation) {
+					sd.loadingDots.Stop()
+				}
+				sd.setResults(results)
+			})
+			sd.resultsGeneration = generation
+		}
 	}()
 }
 


### PR DESCRIPTION
A generation counter is added to the search dialog, which assigns each in-flight search request a number; as the requests complete, they only display their results if their information is newer than what's currently displayed.

This fix is only relevant if the sd.OnSearched callback takes more than 200ms to complete, because of the debouncer in `searchentry.go`.